### PR TITLE
travis build script modification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 script:
   - eval $(opam config env)
   - ./configure.sh
-  - make build
+  - make
   - make html
   - make -C crypto-lib libverse
   - make -C crypto-lib/libverse libverse.a

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ addons:
     sources: [avsm]
 matrix:
   include:
-    env: COQ_VER=8.5.2 OCAML_VER=4.05.0
-    env: COQ_VER=8.6.1 OCAML_VER=4.05.0
-    env: COQ_VER=8.7.2 OCAML_VER=4.05.0
-    env: COQ_VER=8.8.0 OCAML_VER=4.05.0
+    - env: COQ_VER=8.5.2 OCAML_VER=4.05.0
+    - env: COQ_VER=8.6.1 OCAML_VER=4.05.0
+    - env: COQ_VER=8.7.2 OCAML_VER=4.05.0
+    - env: COQ_VER=8.8.0 OCAML_VER=4.05.0
   allow_failures:
     - env: COQ_VER=8.8.0 OCAML_VER=4.05.0
     - env: COQ_VER=8.7.2 OCAML_VER=4.05.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,11 @@ addons:
     sources: [avsm]
 matrix:
   include:
-    - env: COQ_VER=8.5.2 OCAML_VER=4.05.0
     - env: COQ_VER=8.6.1 OCAML_VER=4.05.0
     - env: COQ_VER=8.7.2 OCAML_VER=4.05.0
     - env: COQ_VER=8.8.0 OCAML_VER=4.05.0
   allow_failures:
     - env: COQ_VER=8.8.0 OCAML_VER=4.05.0
-    - env: COQ_VER=8.7.2 OCAML_VER=4.05.0
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 env:
   global:
     - OCAML_VER=4.05.0
+    - OPAMYES=true
   matrix:
     - COQ_VER=8.5.2
     - COQ_VER=8.6.1
@@ -33,9 +34,9 @@ before_install:
   - opam update
   - opam switch install 4.05.0
   - opam switch set 4.05.0
-  - opam install coq."$COQ_VER"
+  - opam install coq."$COQ_VER" -y
   - opam pin add coq "$COQ_VER"
-  - opam install coq-color
+  - opam install coq-color -y
 script:
   - eval $(opam config env)
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ before_install:
   - opam update
   - opam switch install 4.05.0
   - opam switch set 4.05.0
-  - opam install coq."$COQ_VER" -y
+  - opam install coq."$COQ_VER" -y --verbose
   - opam pin add coq "$COQ_VER"
-  - opam install coq-color -y
+  - opam install coq-color -y --verbose
 script:
   - eval $(opam config env)
   - make build

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
   - opam install coq-color -y --verbose
 script:
   - eval $(opam config env)
+  - ./configure.sh
   - make build
   - make html
   - make -C crypto-lib libverse

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ notifications:
 fast_finish: true
 before_install:
   - opam init -y
-  - opam repo add coq-released https://coq.inria.fr/opam/released
+  - (opam repo list | grep coq-released) || opam repo add coq-released https://coq.inria.fr/opam/released
   - opam update
   - opam switch install 4.05.0
   - opam switch set 4.05.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,21 +10,14 @@ addons:
       - opam
       - ghc
     sources: [avsm]
-
-matrix:
-  include:
-    - os: linux
-      env: COQ_VER=8.5.2
-
-    - os: linux
-      env: COQ_VER=8.6.1
-
-    - os: linux
-      env: COQ_VER=8.7.2
-
-    - os: linux
-      env: COQ_VER=8.8.0
-
+env:
+  global:
+    - OCAML_VER=4.05.0
+  matrix:
+    - COQ_VER=8.5.2
+    - COQ_VER=8.6.1
+    - COQ_VER=8.7.2
+    - COQ_VER=8.8.0
 
   allow_failures:
     - env: COQ_VER=8.8.0
@@ -35,12 +28,18 @@ notifications:
   irc: "irc.freenode.net#haskell-raaz"
 fast_finish: true
 before_install:
-  - ./scripts/opam-build.sh init
+  - opam init
+  - opam repo add coq-released https://coq.inria.fr/opam/released
+  - opam update
+  - opam switch install 4.05.0
+  - opam switch set 4.05.0
+  - opam install coq."$COQ_VER"
+  - opam pin add coq "$COQ_VER"
+  - opam install coq-color
 script:
-  - ./scripts/opam-build.sh build
-  - ./scripts/opam-build.sh html
-  - ./scripts/opam-build.sh install
-  - eval `opam config env --root=coq-"$COQ_VER"`
+  - eval $(opam config env)
+  - make build
+  - make html
   - make -C crypto-lib libverse
   - make -C crypto-lib/libverse libverse.a
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,7 @@ language: c
 sudo: false
 cache:
   directories:
-    # Put all the versions of coq that you want here.
-    - coq-8.5.2
-    - coq-8.6
+    - $HOME/.opam
 addons:
   apt:
     packages:
@@ -52,4 +50,4 @@ after_failure:
 branches:
   only:
     - master
-    - syntax
+    - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install:
   - opam init -y
   - (opam repo list | grep coq-released) || opam repo add coq-released https://coq.inria.fr/opam/released
   - opam update
-  - opam switch install 4.05.0
   - opam switch set 4.05.0
   - opam install coq."$COQ_VER" -y --verbose
   - opam pin add coq "$COQ_VER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_install:
   - opam install coq-color -y --verbose
 script:
   - eval $(opam config env)
+  - coqtop --version
   - ./configure.sh
   - make
   - make html

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ notifications:
   irc: "irc.freenode.net#haskell-raaz"
 fast_finish: true
 before_install:
-  - opam init
+  - opam init -y
   - opam repo add coq-released https://coq.inria.fr/opam/released
   - opam update
   - opam switch install 4.05.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,19 +10,15 @@ addons:
       - opam
       - ghc
     sources: [avsm]
-env:
-  global:
-    - OCAML_VER=4.05.0
-    - OPAMYES=true
-  matrix:
-    - COQ_VER=8.5.2
-    - COQ_VER=8.6.1
-    - COQ_VER=8.7.2
-    - COQ_VER=8.8.0
-
+matrix:
+  include:
+    env: COQ_VER=8.5.2 OCAML_VER=4.05.0
+    env: COQ_VER=8.6.1 OCAML_VER=4.05.0
+    env: COQ_VER=8.7.2 OCAML_VER=4.05.0
+    env: COQ_VER=8.8.0 OCAML_VER=4.05.0
   allow_failures:
-    - env: COQ_VER=8.8.0
-    - env: COQ_VER=8.7.2
+    - env: COQ_VER=8.8.0 OCAML_VER=4.05.0
+    - env: COQ_VER=8.7.2 OCAML_VER=4.05.0
 
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ fast_finish: true
 before_install:
   - opam init -y
   - (opam repo list | grep coq-released) || opam repo add coq-released https://coq.inria.fr/opam/released
-  - opam update
-  - opam switch set 4.05.0
+  - opam update -y
+  - opam switch set 4.05.0 -y
   - opam install coq."$COQ_VER" -y --verbose
-  - opam pin add coq "$COQ_VER"
+  - opam pin add coq "$COQ_VER" -y
   - opam install coq-color -y --verbose
 script:
   - eval $(opam config env)

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     sources: [avsm]
 matrix:
   include:
+    - env: COQ_VER=8.6   OCAML_VER=4.05.0
     - env: COQ_VER=8.6.1 OCAML_VER=4.05.0
     - env: COQ_VER=8.7.2 OCAML_VER=4.05.0
     - env: COQ_VER=8.8.0 OCAML_VER=4.05.0


### PR DESCRIPTION
- now uses opam directly instead of the shell script.
- allows building of develop branch.