### PR TITLE
Better array indexing

### DIFF
--- a/src/Verse/CryptoLib/chacha20/c/portable.v
+++ b/src/Verse/CryptoLib/chacha20/c/portable.v
@@ -136,7 +136,7 @@ Module Internal.
      *)
     Definition XORBLOCK (B : progvar (Block variant))(i : nat) (_ : i < 16)
       : code progvar.
-      verse [ Temp ::== B[- i -]; Temp ::=^ X i _; MOVE Temp TO B[- i -] ].
+      verse [ Temp ::== B[- i -]; Temp ::=^ X [- i -]; MOVE Temp TO B[- i -] ].
     Defined.
 
     (** Here we only emit the key stream and is useful when using as csprg *)

--- a/src/Verse/CryptoLib/sha2/c/portable.v
+++ b/src/Verse/CryptoLib/sha2/c/portable.v
@@ -139,11 +139,13 @@ Module SHA2 (C : CONFIG).
                    (sIdx mod BLOCK_SIZE)
                    (NPeano.Nat.mod_upper_bound sIdx BLOCK_SIZE nonZeroBlockSize).
 
-      Definition M  := W idx idxPf.
+      Definition M  : v Word.
+        verse (W[- idx -]).
+      Defined.
 
       (** We capture m(idx - j) using this variable *)
       Definition MM (j : nat) : v Word.
-        verse (W ((idx + 16 - j) mod BLOCK_SIZE) _).
+        verse (W [- (idx + 16 - j) mod BLOCK_SIZE -]).
       Defined.
 
 
@@ -347,7 +349,7 @@ Module SHA2 (C : CONFIG).
 
 
     Definition UPDATE_ITH (i : nat) (pf : i < HASH_SIZE) : code v.
-      verse ([STATE i _ ::=+ hash [- i -]]).
+      verse ([ STATE[- i -] ::=+ hash [- i -]]).
     Defined.
 
     Definition UPDATE : code v


### PR DESCRIPTION
Now the uniform notation `A[- i -]` works for both array indexing and varCache indexing. It seems to
be working in the few places where I tried. @dangabhi you might want to extensively use this and
confirm that it works as desired.