### PR TITLE
reverse translation of variables

### DIFF
--- a/src/Verse/Ast.v
+++ b/src/Verse/Ast.v
@@ -151,12 +151,14 @@ Module LExpr.
              (tr : TypeSystem.translator src tgt)
              (v : Variables.U tgt) (ty : typeOf src direct)
              (le : lexpr (Variables.Universe.coTranslate tr v) ty)
-  : lexpr v (Types.translate tr ty).
-    refine (match le with
-            | @var _ _ ty x => var (ty := Types.translate tr ty) x
-            | @deref _ _ ty b e a i => @deref tgt v (Types.translate tr ty) b e _ i
-            end). rewrite <- (arrayCompatibility tr). exact a.
-    Defined.
+  : lexpr v (Types.translate tr ty)
+    := match le with
+       | @var _ _ ty x => var (ty := Types.translate tr ty) x
+       | @deref _ _ ty b e a i =>
+         let compatPf := arrayCompatibility tr b e ty in
+         let ap  := Variables.translate tr a in
+         deref (rew compatPf in ap) i
+       end.
 
   Arguments translate [src tgt] tr [v ty].
 

--- a/src/Verse/TypeSystem.v
+++ b/src/Verse/TypeSystem.v
@@ -281,7 +281,15 @@ Module Variables.
     : v k (Types.translate tr ty) -> Universe.coTranslate tr v k ty
     := fun x => x.
 
+  Definition translate src tgt
+             (tr : translator src tgt)
+             (v : U tgt) (k : kind)
+             (ty : typeOf src k)
+    : Universe.coTranslate tr v k ty -> v k (Types.translate tr ty)
+    := fun x => x.
+
   Arguments coTranslate [src tgt] tr [v k ty].
+  Arguments translate [src tgt] tr [v k ty].
 
   Definition coInject ts : forall (v : U (result ts)) k (ty : typeOf ts k),
       v k (Types.inject ty) -> Universe.coInject v k ty


### PR DESCRIPTION
For variables the natural function is coTranslate: target variables to source variables. It so happens that this function is just identity and hence invertible. We implement the inverse and use it to simplify some code that was previously written using tactics.
