### PR TITLE
Verse constants are bit vectors

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -6,8 +6,9 @@ src/Verse/FFI/Raaz.v
 src/Verse/FFI/Raaz/Target/C.v
 src/Verse/Language.v
 src/Verse/Language/Macros.v
-src/Verse/Language/Macros/Loops.v
+src/Verse/Language/Macros/BitOps.v
 src/Verse/Language/Macros/Cache.v
+src/Verse/Language/Macros/Loops.v
 src/Verse/Language/Pretty.v
 src/Verse/Language/Types.v
 src/Verse/Machine.v

--- a/src/Verse/CryptoLib/blake2.v
+++ b/src/Verse/CryptoLib/blake2.v
@@ -2,14 +2,16 @@ Require Import Verse.
 
 Module Type CONFIG.
 
-  (** The word size for the hash *)
-  Parameter WORD_LOG_SIZE : nat.
+  (** The basic word of the hash. For blake2b it is [Word64] where as
+      for blake2s it is [Word32]
+   *)
+  Parameter Word : type direct.
 
   (** The number of rounds that is involved in hashing. *)
   Parameters ROUNDS : nat.
 
   (** The round constants for the hash *)
-  Parameter IVVec : Vector.t (constant (word WORD_LOG_SIZE)) 8.
+  Parameter IVVec : Vector.t (constant Word) 8.
 
   (** The rotation constants used by the G function *)
   Parameter R0 R1 R2 R3 : nat.

--- a/src/Verse/CryptoLib/blake2b/c/portable.v
+++ b/src/Verse/CryptoLib/blake2b/c/portable.v
@@ -7,9 +7,9 @@ Import Vector.VectorNotations.
 
 Module Config <: CONFIG.
 
-  Definition WORD_LOG_SIZE := 3.
-  Definition ROUNDS        := 12.
-  Definition IVVec          :=
+  Definition Word   := Word64.
+  Definition ROUNDS := 12.
+  Definition IVVec  :=
     [
       Ox "6a09e667f3bcc908";
       Ox "bb67ae8584caa73b";

--- a/src/Verse/CryptoLib/blake2s/c/portable.v
+++ b/src/Verse/CryptoLib/blake2s/c/portable.v
@@ -7,9 +7,9 @@ Import Vector.VectorNotations.
 
 Module Config <: CONFIG.
 
-  Definition WORD_LOG_SIZE := 2.
-  Definition ROUNDS        := 10.
-  Definition IVVec          :=
+  Definition Word   := Word32.
+  Definition ROUNDS := 10.
+  Definition IVVec  :=
     [
      Ox "6a09e667";
      Ox "bb67ae85";

--- a/src/Verse/Language/Macros.v
+++ b/src/Verse/Language/Macros.v
@@ -1,2 +1,3 @@
-Require Export Verse.Language.Macros.Loops.
+Require Export Verse.Language.Macros.BitOps.
 Require Export Verse.Language.Macros.Cache.
+Require Export Verse.Language.Macros.Loops.

--- a/src/Verse/Language/Macros/BitOps.v
+++ b/src/Verse/Language/Macros/BitOps.v
@@ -1,0 +1,98 @@
+Require Import Bvector.
+Require Import BinNat.
+Require Import Arith.
+Require Import NArith.
+
+
+Require Import Verse.Ast.
+Require Import Verse.TypeSystem.
+Require Import Verse.Language.Types.
+
+Module Internals.
+
+
+  Definition selL (n : nat) {m} : Bvector m
+    := N2Bv_sized m (2^(N.of_nat n) -1).
+
+  Definition clearU n {m} := @selL (m - n) m.
+
+  Definition selU n   {m} := Bneg m (clearU n).
+  Definition clearL n {m} := Bneg m (selL n).
+
+
+  Definition selLC (ty : type direct) n : const ty
+  := let mask sz : const (word sz) := selL n in
+     match ty with
+     | word sz         => mask sz
+     | multiword m sz  => Vector.const (mask sz) (2^m)
+     end.
+
+  Definition selUC (ty : type direct) n : const ty
+    := let mask sz : const (word sz) := selU n in
+       match ty with
+       | word sz         => mask sz
+       | multiword m sz  => Vector.const (mask sz) (2^m)
+       end.
+
+
+  Definition clearLC (ty : type direct) n : const ty
+    := let mask sz : const (word sz) := clearL n in
+       match ty with
+       | word sz         => mask sz
+       | multiword m sz  => Vector.const (mask sz) (2^m)
+       end.
+
+
+  Definition clearUC (ty : type direct) n : const ty
+    := let mask sz : const (word sz) := clearU n in
+       match ty with
+       | word sz         => mask sz
+       | multiword m sz  => Vector.const (mask sz) (2^m)
+       end.
+
+  Definition selShiftR (ty : type direct) n : nat
+    := match ty with
+       | word sz => bitSize sz - n
+       | multiword _ sz => bitSize sz - n
+       end.
+End Internals.
+
+(**  Expression that selects the n most significant bits of a constant *)
+
+
+
+Require Import Verse.Language.Pretty.
+
+(** * Select or clear bits
+
+The [selectLower n] ([selectUpper n]) selects the lower (respectively
+upper) bits of the given constant expression.  Similarly [clearLower
+n] ([clearUpper n]) clears the lower (respectively upper) bits.  If
+the expression is of type multiword, then the select/clear functions
+selects or clears n bits from each of the component of the multiword.
+
+*)
+
+Definition selectLower (n : nat) {v : VariableT}{ty : type direct }{E}{inst : EXPR v ty E} (e: E)
+  := e AND (Internals.selLC ty n).
+
+Definition selectUpper (n : nat) {v : VariableT}{ty : type direct }{E}{inst : EXPR v ty E} (e: E)
+  := e AND (Internals.selUC ty n).
+
+Definition clearLower (n : nat) {v : VariableT}{ty : type direct }{E}{inst : EXPR v ty E} (e: E)
+  := e AND (Internals.clearLC ty n).
+
+Definition clearUpper (n : nat) {v : VariableT}{ty : type direct }{E}{inst : EXPR v ty E} (e: E)
+  := e AND (Internals.clearUC ty n).
+
+(**
+    This function selects the upper [n] bits and then shifts the lower n-m bits out. As numbers
+    this corresponds to taking remainder with
+
+*)
+Definition selectAndShiftR  (n : nat) {v : VariableT}{ty : type direct }{E}{inst : EXPR v ty E} (e: E)
+  := e >> (Internals.selShiftR ty n).
+
+Definition selectShiftRAndUpdate  (n : nat)
+           {v : VariableT}{ty : type direct }{L}{inst : LEXPR v ty L} (l: L)
+  := l ::=>> (Internals.selShiftR ty n).

--- a/src/Verse/Language/Pretty.v
+++ b/src/Verse/Language/Pretty.v
@@ -130,6 +130,10 @@ Section Embedding.
     End Operators.
 End Embedding.
 
+Instance bvec_to_expr v sz : EXPR v (word sz) (BWord sz)
+  := { toExpr := fun v : const (word sz) => cval v }.
+Instance nibbles_to_exp v sz  : EXPR v (word sz) (Nibble.bytes (2^sz))
+  := { toExpr := fun nibs => toExpr (toBv nibs) }.
 
 
 Arguments assignStmt [v ty t] lhs [class t1] e1 [class1].

--- a/src/Verse/Language/Types.v
+++ b/src/Verse/Language/Types.v
@@ -3,6 +3,8 @@ Require Verse.Nibble.
 Require Import Verse.TypeSystem.
 Require Import Arith.
 Require Import NArith.
+Require Import Bvector.
+Require Import BinNat.
 (* end hide *)
 
 (** ** The type system for Verse.
@@ -20,17 +22,23 @@ Inductive type       : kind -> Type :=
 | multiword          : nat -> nat    -> type direct
 | array              : nat -> endian -> type direct -> type memory.
 
+(** Size of a word in bits *)
+Definition bitSize sz := 4 * (2 * 2^sz).
+
+(** This is what a word of size means as a bit vector *)
+Definition BWord sz := Bvector (bitSize sz).
+
 Definition const (t : type direct) :=
   match t with
-  | word n => Nibble.bytes (2^n)
-  | multiword m n => Vector.t (Nibble.bytes (2^n))  (2 ^ m)
+  | word sz => BWord sz
+  | multiword m sz => Vector.t (BWord sz)  (2 ^ m)
   end.
 
 Definition NToConst (ty : type direct) (num : N) : const ty
-  := let numtrunc n := @Nibble.fromN (2 * 2^n) num in
+  := let numtrunc sz : BWord sz := N2Bv_sized _ num in
      match ty in type direct return const ty with
-     | word n => numtrunc n
-     | multiword m n => Vector.const (numtrunc n) (2^m)
+     | word sz => numtrunc sz
+     | multiword m sz => Vector.const (numtrunc sz) (2^m)
      end.
 
 Definition natToConst (ty : type direct) (num : nat) : const ty

--- a/src/Verse/Nibble.v
+++ b/src/Verse/Nibble.v
@@ -211,5 +211,6 @@ End ConversionToString.
 
 (* end hide *)
 
-Definition Ox s := let t := ConversionToString.trim_separators s
-                   in recover (ConversionToString.fromString (String.length t) t).
+Definition Ox s := let t := ConversionToString.trim_separators s in
+                   recover (nibs <- ConversionToString.fromString (String.length t) t;
+                              {- toBv nibs -}).

--- a/src/Verse/Target/C/CodeGen.v
+++ b/src/Verse/Target/C/CodeGen.v
@@ -176,7 +176,7 @@ Module Config <: CONFIG.
                return Types.const (word n0)
                       -> constOf targetTs (trType (word n0))
          with
-         | 0 | 1 | 2 | 3  => fun x => Vector.to_list x
+         | 0 | 1 | 2 | 3  => fun x => Vector.to_list (Nibble.fromBv x)
          | _ => fun x : _ => error (CouldNotTranslate x)
          end
        | multiword _ _  => fun x => error (CouldNotTranslate x)


### PR DESCRIPTION
With this changes, verse constants are represented as bit vectors. As a result some bitwise operation macros have been defined which simplifies previous code. It will hopefully make the bitvector semantics also easier.