### PR TITLE
Basic support for building with dune

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        coq: [ '8.11.0', '8.10.2', '8.9.1']
+        coq: [ '8.12.2', '8.11.2', '8.10.2', '8.9.1']
     env:
       COQVER:  ${{ matrix.coq }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Coq Installation
         run: |
           opam pin add coq "$COQVER" -y
-
+          opam install dune -y
       - name: Build
         run: |
           eval $(opam config env)
@@ -46,6 +46,11 @@ jobs:
           eval $(opam config env)
           coqtop --version
           make test
+      - name: Dune build
+        run: |
+          eval $(opam config env)
+          make clean
+          dune build
       - name: Documentation
         run: |
           eval $(opam config env)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
       - name: Coq Installation
         run: |
           opam pin add coq "$COQVER" -y
+      - name: Dune build
+        run: |
           opam install dune -y
+          eval $(opam config env)
+          dune build
       - name: Build
         run: |
           eval $(opam config env)
@@ -46,11 +50,6 @@ jobs:
           eval $(opam config env)
           coqtop --version
           make test
-      - name: Dune build
-        run: |
-          eval $(opam config env)
-          make clean
-          dune build
       - name: Documentation
         run: |
           eval $(opam config env)

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ clean: subdirs-clean
 	rm -f Makefile.coq Makefile.coq.conf
 
 subdirs-clean:
-	$(foreach dir, ${SUBDIRS}, make -C ${dir} clean; )
-
+	$(foreach dir, ${SUBDIRS}, make -C ${dir} clean;)
+	$(foreach dir, ${SUBDIRS} src, rm -f `find ${dir} -name '.*.aux'`)
 
 Makefile.coq: _CoqProject
 	coq_makefile -f _CoqProject -o $@

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,7 @@
+(lang dune 2.5)
+(using coq 0.2)
+(license Apache-2.0)
+(source (github "raaz-crypto/verse-coq"))
+(generate_opam_files true)
+(package
+  (name verse))

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,47 @@
+(coq.theory
+ (name Verse)
+ (package verse)
+ (synopsis "A EDSL to write crypto primitives")
+ (modules Verse
+	  Verse.Ast
+	  Verse.Error
+	  Verse.FFI.Raaz
+	  Verse.FFI.Raaz.Target.C
+	  Verse.Language
+	  Verse.Language.Macros
+	  Verse.Language.Macros.BitOps
+	  Verse.Language.Macros.Cache
+	  Verse.Language.Macros.Loops
+	  Verse.Language.Pretty
+	  Verse.Language.Types
+	  Verse.Machine
+	  Verse.Machine.BitVector
+	  Verse.BitVector
+	  Verse.BitVector.Facts
+	  Verse.BitVector.ArithRing
+	  Verse.Machine.Hoare
+	  Verse.Monoid
+	  Verse.Monoid.Semantics
+	  Verse.NFacts
+	  Verse.Nibble
+	  Verse.Print
+	  Verse.Scope
+	  Verse.Target
+	  Verse.Target.C
+	  Verse.Target.C.Ast
+	  Verse.Target.C.CodeGen
+	  Verse.Target.C.Pretty
+	  Verse.TypeSystem
+	  Verse.CryptoLib.blake2
+	  Verse.CryptoLib.blake2.c.portable
+	  Verse.CryptoLib.blake2b.c.portable
+	  Verse.CryptoLib.blake2s.c.portable
+	  Verse.CryptoLib.chacha20.common
+	  Verse.CryptoLib.chacha20.c.portable
+	  Verse.CryptoLib.poly1305.c.portable
+	  Verse.CryptoLib.sha2
+	  Verse.CryptoLib.sha2.c.portable
+	  Verse.CryptoLib.sha256.c.portable
+	  Verse.CryptoLib.sha512.c.portable
+	  ))
+(include_subdirs qualified)

--- a/test/TestCode.v
+++ b/test/TestCode.v
@@ -1,8 +1,7 @@
+From Verse Require Import Verse Nibble.
 Require Import Nat.
 Require Import NArith.
-Require Import Verse.
 Import VerseNotations.
-Require Import Verse.Nibble.
 Require Import String.
 Open Scope string_scope.
 Import List.ListNotations.

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,5 @@
+(coq.theory
+ (name versetest)
+ (synopsis "Some test scripts")
+ (theories Verse)
+ (modules TestCode))


### PR DESCRIPTION
The dune build currently only builds the library and the tests. A more extensive support should separate out the Verse library from the cryptolib implementations. That will be done latter
