### PR TITLE
Variable renaming

### DIFF
--- a/src/Verse/AbstractMachine.v
+++ b/src/Verse/AbstractMachine.v
@@ -103,9 +103,8 @@ transformation machine, parametrized on a variable type.
   Class State :=
     {
       str : Type;
-      val  : forall (Str : str)
-                     {k} {ty : type k} (var : v _ ty),
-              typeTrans tyD ty : Type;
+      val  : str -> Variables.renaming v (typeTrans tyD);
+
       storeUpdate
       : forall {k} {ty : type k} (var : v _ ty)
                (f : typeTrans tyD ty -> typeTrans tyD ty),
@@ -114,9 +113,9 @@ transformation machine, parametrized on a variable type.
       evalUpdate
       : forall (s : str) k (ty : type k) (var : v _ ty) f,
           forall k' (ty' : type k') (v' : v _ ty'),
-            ( ~ eq_dep2 var v'-> val (storeUpdate var f s) v' = val s v')
+            ( ~ eq_dep2 var v'-> val (storeUpdate var f s) _ _ v' = val s _ _ v')
             /\
-            val (storeUpdate var f s) var = f (val s var)
+            val (storeUpdate var f s) _ _ var = f (val s _ _ var)
 
     }.
 

--- a/src/Verse/AbstractMachine.v
+++ b/src/Verse/AbstractMachine.v
@@ -58,6 +58,29 @@ Definition abstract_type_system : typeSystem
 
 Definition typeDenote ts := TypeSystem.translator ts abstract_type_system.
 
+Section Evaluation.
+  Context {ts : typeSystem}
+          (tyD : typeDenote ts).
+
+
+  Definition evalLexp {T} (l : lexpr (typeTrans tyD) T) : typeTrans tyD T
+      := match l with
+         | Ast.var x      => x
+         | Ast.deref v idx  => Vector.nth_order
+                                 (rew [id] arrayCompatibility tyD _ _ _ in v)
+                                 (proj2_sig idx)
+         end.
+
+    Fixpoint eval {T} (e : expr (typeTrans tyD) T) :  typeTrans tyD T
+      := match e with
+         | Ast.cval c => constTrans tyD c
+         | Ast.valueOf lv => evalLexp lv
+         | Ast.binOp o e0 e1 => (opTrans tyD o) (eval e0) (eval e1)
+         | Ast.uniOp o e0    => (opTrans tyD o) (eval e0)
+         end.
+End Evaluation.
+
+
 Section Store.
 
   (** * Abstract state machines.

--- a/src/Verse/AbstractMachine.v
+++ b/src/Verse/AbstractMachine.v
@@ -152,21 +152,8 @@ Module Internals.
     Definition expr  T := Ast.expr  v T.
     Definition lexpr T := Ast.lexpr v T.
 
-    Definition leval {T} (l : lexpr T) (st : str) : typeTrans tyD T
-      := match l with
-         | Ast.var reg      => val st reg
-         | Ast.deref v idx  => Vector.nth_order
-                                 (rew [id] arrayCompatibility tyD _ _ _ in val st v)
-                                 (proj2_sig idx)
-         end.
-
     Fixpoint evalE {T} (st : str) (e : expr T) :  typeTrans tyD T
-      := match e with
-         | Ast.cval c => constTrans tyD c
-         | Ast.valueOf lv => leval lv st
-         | Ast.binOp o e0 e1 => (opTrans tyD o) (evalE st e0) (evalE st e1)
-         | Ast.uniOp o e0    => (opTrans tyD o) (evalE st e0)
-         end.
+      := eval tyD (Expr.rename (val st) e).
 
     Definition assign {T} (l : lexpr T) (e : expr T)(st : str)
       : str

--- a/src/Verse/Ast.v
+++ b/src/Verse/Ast.v
@@ -179,6 +179,13 @@ Require Import Verse.Error.
 
 Module LExpr.
 
+  (** Function for renaming variables *)
+  Definition rename {ts}{u v : Variables.U ts}(rn : Variables.renaming u v) {ty : ts direct} (l : lexpr u ty)
+      := match l with
+         | var x => var (rn direct _ x)
+         | deref a i => deref (rn memory _ a) i
+         end.
+
   Definition translate src tgt
              (tr : TypeSystem.translator src tgt)
              (v : Variables.U tgt) (ty : typeOf src direct)
@@ -224,10 +231,24 @@ Module LExpr.
     := extract (translate cr le).
 
   Arguments compile [src tgt] cr [v ty].
-*)
+ *)
+
+
+
 End LExpr.
 
 Module Expr.
+
+  (** Renaming variables in an expression *)
+  Fixpoint rename {ts}{u v : Variables.U ts}(rn : Variables.renaming u v) {ty : ts direct} (e : expr u ty)
+  : expr v ty
+    := match e with
+         | cval c        => cval c
+         | valueOf x     => valueOf (LExpr.rename rn x)
+         | uniOp o e0    => uniOp o (rename rn e0)
+         | binOp o e0 e1 => binOp o (rename rn e0) (rename rn e1)
+       end.
+
 
   Fixpoint translate {src tgt}
            (tr : TypeSystem.translator src tgt)

--- a/src/Verse/TypeSystem.v
+++ b/src/Verse/TypeSystem.v
@@ -260,6 +260,8 @@ Module Variables.
   (** The universe of variables (of a given type system) *)
   Definition U ts := forall k, typeOf ts k -> Type.
 
+  Definition renaming {ts} (u v : U ts) := forall k (ty : ts k),  u k ty -> v k ty.
+
   Module Universe.
 
     Definition coTranslate src tgt


### PR DESCRIPTION
A fundamental operation is to rename one type of variables with another. These commits add variable renaming. We then use this renaming to simplify the evaluation of expression under as store.